### PR TITLE
Start use __qualname__ for throttle empty scope instead of uuid

### DIFF
--- a/tests/controllers/__init__.py
+++ b/tests/controllers/__init__.py
@@ -7,7 +7,6 @@ from .controller_with_path_parameters import ControllerWithPathParameters
 from .controller_with_query_parameters import ControllerWithQueryParameters
 from .controller_with_response_headers import ControllerWithResponseHeaders
 from .controller_with_serializer import ControllerWithSerializer
-from .controller_with_throttling import ControllerWithThrottlingOnController
 from .controller_with_throttling import ControllerWithThrottlingOnMethod
 from .no_authentication_controller import NoAuthenticationController
 from .simple_controller import SimpleController

--- a/tests/controllers/controller_with_throttling.py
+++ b/tests/controllers/controller_with_throttling.py
@@ -1,24 +1,4 @@
-import winter.http
 import winter
-
-
-@winter.http.throttling('6/s', scope='ControllerWithThrottlingOnController')
-@winter.no_authentication
-@winter.route_get('with-throttling-on-controller/')
-class ControllerWithThrottlingOnController:
-
-    @winter.route_get()
-    def simple_method(self):
-        return 1
-
-    @winter.route_get('same/')
-    def same_simple_method(self):
-        return 1
-
-    @winter.http.throttling(None)
-    @winter.route_post()
-    def method_without_throttling(self):
-        return None
 
 
 @winter.route_get('with-throttling-on-method/')

--- a/tests/test_throttling.py
+++ b/tests/test_throttling.py
@@ -1,55 +1,9 @@
-import sys
-
-import datetime
 from http import HTTPStatus
 
 import pytest
 from rest_framework.test import APIClient
 
 from .entities import AuthorizedUser
-
-
-@pytest.mark.parametrize('need_auth', (True, False))
-def test_throttling(need_auth):
-    client = APIClient()
-
-    if need_auth:
-        user = AuthorizedUser()
-        client.force_authenticate(user)
-
-    for i in range(1, 5):
-        response = client.get('/with-throttling-on-controller/')
-        response_of_same = client.get('/with-throttling-on-controller/same/')
-
-        if i > 6 // 2:
-            assert response.status_code == response_of_same.status_code == HTTPStatus.TOO_MANY_REQUESTS, i
-        else:
-            assert response.status_code == response_of_same.status_code == HTTPStatus.OK, i
-
-
-def test_throttling_discards_old_requests():
-    if sys.version_info > (3, 8):
-        return
-
-    from freezegun import freeze_time
-
-    client = APIClient()
-    user = AuthorizedUser()
-    client.force_authenticate(user)
-
-    with freeze_time(datetime.datetime(2000, 1, 1, second=0, microsecond=0)):
-        for _ in range(3):
-            client.get('/with-throttling-on-controller/')
-
-    with freeze_time(datetime.datetime(2000, 1, 1, second=0, microsecond=600000)):
-        for _ in range(2):
-            client.get('/with-throttling-on-controller/')
-
-    # Act
-    with freeze_time(datetime.datetime(2000, 1, 1, second=1, microsecond=0)):
-        response = client.get('/with-throttling-on-controller/')
-
-    assert response.status_code == HTTPStatus.OK
 
 
 @pytest.mark.parametrize('need_auth', (True, False))
@@ -68,16 +22,12 @@ def test_throttling_on_method(need_auth):
             assert response.status_code == response_of_same.status_code == HTTPStatus.OK, i
 
 
-@pytest.mark.parametrize(('url', 'method'), (
-    ('/with-throttling-on-method/without-throttling/', 'get'),
-    ('/with-throttling-on-controller/', 'post'),
-))
-def test_throttling_without_throttling(url, method):
+def test_throttling_without_throttling():
     client = APIClient()
     user = AuthorizedUser()
     client.force_authenticate(user)
 
     for i in range(1, 10):
-        client_method = getattr(client, method)
-        response = client_method(url)
+        client_method = getattr(client, 'get')
+        response = client_method('/with-throttling-on-method/without-throttling/')
         assert response.status_code == HTTPStatus.OK, i

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -12,7 +12,6 @@ urlpatterns = [
     *winter.django.create_django_urls(controllers.ControllerWithQueryParameters),
     *winter.django.create_django_urls(controllers.ControllerWithResponseHeaders),
     *winter.django.create_django_urls(controllers.ControllerWithSerializer),
-    *winter.django.create_django_urls(controllers.ControllerWithThrottlingOnController),
     *winter.django.create_django_urls(controllers.ControllerWithThrottlingOnMethod),
     *winter.django.create_django_urls(controllers.ControllerWithLimits),
     *winter.django.create_django_urls(controllers.ControllerWithRequestData),


### PR DESCRIPTION
**Start use __qualname__ for throttle empty scope instead of UUID**

For apps running in several workers throttling works incorrectly:
if the scope was not specified UUID was used. This led to using the same endpoints more than forbidden times - because of using different UUIDs in each worker.

Now if the scope is not set, the full name of the method will be used.
It gets __qualname__ of the method.

With this using @winter.http.throttling is not applicable - It's not obvious how throttling should work in cases when the scope is set or when it's empty
So now it's possible to add @winter.http.throttling only on the methods.
